### PR TITLE
Add io.js 0.12.0-dev

### DIFF
--- a/share/node-build/iojs-0.12.0-dev
+++ b/share/node-build/iojs-0.12.0-dev
@@ -1,0 +1,1 @@
+install_git "iojs-0.12.0-dev" "https://github.com/iojs/io.js.git" "v0.12" standard


### PR DESCRIPTION
This pull request adds a definition for building [io.js](https://github.com/iojs/io.js) with v0.12 development branch on GitHub repository.