### PR TITLE
Getting versions from iojs and nodejs

### DIFF
--- a/tools/iojs_scraper.js
+++ b/tools/iojs_scraper.js
@@ -1,0 +1,36 @@
+var http    = require('https'),
+  	fs      = require('fs'),
+    baseUrl = "https://github.com/iojs/io.js.git";
+
+function generateNodeFile (item) {
+  var version   = "iojs-" + item.version,
+    installLine = 'install_git "' + version + '" "' + baseUrl  + '" "' + item.version + '" standard',
+    filePath    = '../share/node-build/' + version;
+
+  fs.exists(filePath,function(exists){
+    if(!exists){
+      fs.writeFile(filePath, installLine, function(err){
+
+        if(err) {
+          console.log(err);
+        } else {
+          console.log(version + ' file writen');
+        }
+      });
+    }
+  });
+}
+
+exports.versions = function getVersions () {
+  http.get("https://iojs.org/download/release/index.json", function(res) {
+    var versions = "";
+    res.on('data', function(data) {
+      versions += data;
+    });
+
+    res.on('end', function() {
+      versions = JSON.parse(versions);
+      versions.forEach(generateNodeFile);
+    });
+  });
+};

--- a/tools/node_scraper.js
+++ b/tools/node_scraper.js
@@ -1,0 +1,83 @@
+var http = require('http'),
+  	fs = require('fs'),
+	baseUrl = "http://nodejs.org/dist/",
+	generateNodeFile = function( version ){
+		var shaUrl = baseUrl + version + "/" + "SHASUMS.txt",
+			shaData,
+			shaLine,
+			installLine,
+			parts,
+			filePath
+
+		http.get(shaUrl, function( res ){
+
+			shaData = ''
+
+			res.on('data', function(data){
+				shaData = shaData + data
+			})
+
+			res.on('end', function(){
+
+				shaLine = shaData.match(/[\da-zA-Z]{40}  node-v[\d]{1,2}\.[\d]{1,2}\.[\d]{1,2}.tar.gz/gi)
+				if(shaLine && shaLine.length){
+
+					parts = shaLine[0].split('  ')
+					//this is gnarly, oh well
+					//install_package "node-v0.10.0" "http://nodejs.org/dist/v0.10.0/node-v0.10.0.tar.gz#7321266347dc1c47ed2186e7d61752795ce8a0ef"
+					installLine = 'install_package "node-' + version + '" "' + baseUrl + version + '/' + parts[1] + '#'+parts[0]+'"'
+					filePath = '../share/node-build/' + version.substring(1)
+					fs.exists(filePath,function(exists){
+
+						if(!exists){
+
+							fs.writeFile(filePath, installLine, function(err){
+
+								if(err)
+							        console.log(err)
+							    else
+							        console.log( version.substring(1) + ' file writen')
+
+							})
+
+						}
+
+					})
+
+				}
+
+			})
+
+		})
+
+	}
+
+exports.versions = function getVersions () {
+  http.get(baseUrl, function(res){
+    if( res.statusCode === 200){
+
+      var responseData = "",
+        digestableUrls
+
+      res.on('data', function( data ){
+        responseData = responseData + data
+      })
+
+      res.on('end', function(){
+        digestableUrls = responseData.match(/href=\"v\d\.[\d]{0,2}\.[\d]{0,2}\/\"/g)
+        digestableUrls = digestableUrls.map(function( url ){
+          return url.replace(/href=\"([^"]*)\"/, "$1")
+        })
+
+        digestableUrls.forEach(function( url ){
+          generateNodeFile(url.substring(0, url.length - 1))
+        })
+      })
+
+    } else {
+
+      console.log('response "' + res.status + '" from http://nodejs.org/dist/')
+
+    }
+  })
+};

--- a/tools/scraper.js
+++ b/tools/scraper.js
@@ -1,83 +1,8 @@
-var http = require('http'),
-  	fs = require('fs'),
-	baseUrl = "http://nodejs.org/dist/",
-	generateNodeFile = function( version ){
-		var shaUrl = baseUrl + version + "/" + "SHASUMS.txt",
-			shaData,
-			shaLine,
-			installLine,
-			parts,
-			filePath
+var nodeVersions = require('./node_scraper.js').versions;
+var iojsVersions = require('./iojs_scraper.js').versions;
 
-		http.get(shaUrl, function( res ){
-			
-			shaData = ''
-			
-			res.on('data', function(data){
-				shaData = shaData + data
-			})
+console.log('Updating node versions');
+nodeVersions();
 
-			res.on('end', function(){
-				
-				shaLine = shaData.match(/[\da-zA-Z]{40}  node-v[\d]{1,2}\.[\d]{1,2}\.[\d]{1,2}.tar.gz/gi)
-				if(shaLine && shaLine.length){
-					
-					parts = shaLine[0].split('  ')
-					//this is gnarly, oh well
-					//install_package "node-v0.10.0" "http://nodejs.org/dist/v0.10.0/node-v0.10.0.tar.gz#7321266347dc1c47ed2186e7d61752795ce8a0ef" 
-					installLine = 'install_package "node-' + version + '" "' + baseUrl + version + '/' + parts[1] + '#'+parts[0]+'"'
-					filePath = '../share/node-build/' + version.substring(1)
-					fs.exists(filePath,function(exists){
-
-						if(!exists){
-
-							fs.writeFile(filePath, installLine, function(err){
-					
-								if(err)
-							        console.log(err)
-							    else
-							        console.log( version.substring(1) + ' file writen')
-							    
-							})
-
-						}
-
-					})
-
-				}
-
-			})
-
-		})
-
-	}
-
-
-http.get(baseUrl, function(res){
-	if( res.statusCode === 200){
-
-		var responseData = "",
-			digestableUrls
-
-		res.on('data', function( data ){
-			responseData = responseData + data
-		})
-
-		res.on('end', function(){
-			digestableUrls = responseData.match(/href=\"v\d\.[\d]{0,2}\.[\d]{0,2}\/\"/g)
-			digestableUrls = digestableUrls.map(function( url ){
-				return url.replace(/href=\"([^"]*)\"/, "$1")
-			})
-
-			digestableUrls.forEach(function( url ){
-				generateNodeFile(url.substring(0, url.length - 1))
-			})
-		})
-
-	} else {
-		
-		console.log('response "' + res.status + '" from http://nodejs.org/dist/')
-
-	}
-
-})
+console.log('Updating iojs versions');
+iojsVersions();


### PR DESCRIPTION
I did some changes in `scraper.js`.
Now you can get all node versions from [nodejs.org](http://nodejs.org/) and  [iojs.io](https://iojs.org/en/index.html)
First time doing some open source contribution so if is rude to open a PR like this please tell me how I can help.