### PR TITLE
remove the 'v' prefix from iojs version names

### DIFF
--- a/tools/iojs_scraper.js
+++ b/tools/iojs_scraper.js
@@ -3,7 +3,7 @@ var http    = require('https'),
     baseUrl = "https://github.com/iojs/io.js.git";
 
 function generateNodeFile (item) {
-  var version   = "iojs-" + item.version,
+  var version   = "iojs-" + item.version.replace(/^v/,''),
     installLine = 'install_git "' + version + '" "' + baseUrl  + '" "' + item.version + '" standard',
     filePath    = '../share/node-build/' + version;
 


### PR DESCRIPTION
following the pattern of node version names (which are just the bare
version number), strip the leading v from iojs version names.

so iojs-v1.0.0 -> iojs-1.0.0 (both in filename, and install listing)