### PR TITLE
make scraper safe to run from root or tools/

### DIFF
--- a/tools/iojs_scraper.js
+++ b/tools/iojs_scraper.js
@@ -1,11 +1,12 @@
 var http    = require('https'),
-  	fs      = require('fs'),
+    fs      = require('fs'),
+    path    = require('path'),
     baseUrl = "https://github.com/iojs/io.js.git";
 
 function generateNodeFile (item) {
   var version   = "iojs-" + item.version,
     installLine = 'install_git "' + version + '" "' + baseUrl  + '" "' + item.version + '" standard',
-    filePath    = '../share/node-build/' + version;
+    filePath    = path.join(__dirname, '../share/node-build', version);
 
   fs.exists(filePath,function(exists){
     if(!exists){

--- a/tools/node_scraper.js
+++ b/tools/node_scraper.js
@@ -1,5 +1,6 @@
 var http = require('http'),
-  	fs = require('fs'),
+	fs = require('fs'),
+	path = require('path'),
 	baseUrl = "http://nodejs.org/dist/",
 	generateNodeFile = function( version ){
 		var shaUrl = baseUrl + version + "/" + "SHASUMS.txt",
@@ -26,7 +27,7 @@ var http = require('http'),
 					//this is gnarly, oh well
 					//install_package "node-v0.10.0" "http://nodejs.org/dist/v0.10.0/node-v0.10.0.tar.gz#7321266347dc1c47ed2186e7d61752795ce8a0ef"
 					installLine = 'install_package "node-' + version + '" "' + baseUrl + version + '/' + parts[1] + '#'+parts[0]+'"'
-					filePath = '../share/node-build/' + version.substring(1)
+					filePath = path.join(__dirname, '../share/node-build', version.substring(1))
 					fs.exists(filePath,function(exists){
 
 						if(!exists){


### PR DESCRIPTION
Currently, the node and iojs scrapers must be run with tools/ as the CWD. This change makes the scrapers robust and can be run from anywhere. (the files are written to the share/node-build/ directory relative to the tools/ directory, not relative to CWD