### PR TITLE
iojs versions 1.6.*-2.0.0

### DIFF
--- a/share/node-build/iojs-1.6.3
+++ b/share/node-build/iojs-1.6.3
@@ -1,0 +1,1 @@
+install_git "iojs-1.6.3" "https://github.com/iojs/io.js.git" "v1.6.3" standard

--- a/share/node-build/iojs-1.6.4
+++ b/share/node-build/iojs-1.6.4
@@ -1,0 +1,1 @@
+install_git "iojs-1.6.4" "https://github.com/iojs/io.js.git" "v1.6.4" standard

--- a/share/node-build/iojs-1.7.1
+++ b/share/node-build/iojs-1.7.1
@@ -1,0 +1,1 @@
+install_git "iojs-1.7.1" "https://github.com/iojs/io.js.git" "v1.7.1" standard

--- a/share/node-build/iojs-1.8.1
+++ b/share/node-build/iojs-1.8.1
@@ -1,0 +1,1 @@
+install_git "iojs-1.8.1" "https://github.com/iojs/io.js.git" "v1.8.1" standard

--- a/share/node-build/iojs-2.0.0
+++ b/share/node-build/iojs-2.0.0
@@ -1,0 +1,1 @@
+install_git "iojs-2.0.0" "https://github.com/iojs/io.js.git" "v2.0.0" standard


### PR DESCRIPTION
Using iojs scraper from #42 (omitting 'v' prefix from iojs identifiers)