### PR TITLE
Added sha256 computation and updated 4.0.0 definition

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -163,6 +163,20 @@ compute_sha1() {
   fi
 }
 
+compute_sha256() {
+  if type sha1 &>/dev/null; then
+    sha1 -q
+  elif type openssl &>/dev/null; then
+    local output=$(openssl dgst -sha256)
+    echo "${output##* }"
+  elif type sha256sum &>/dev/null; then
+    local output="$(sha256sum)"
+    echo "${output% *}"
+  else
+    return 1
+  fi
+}
+
 verify_checksum() {
   # If there's no MD5 support, return success
   [ -n "$HAS_SHA1_SUPPORT" ] || return 0
@@ -176,8 +190,15 @@ verify_checksum() {
   [ -n "$expected_checksum" ] || return 0
 
   # If the computed checksum is empty, return failure
-  local computed_checksum=`echo "$(compute_sha1 < "$filename")" | tr [A-Z] [a-z]`
-  [ -n "$computed_checksum" ] || return 1
+
+
+  if [ ${#expected_checksum} == 64 ]; then
+    local computed_checksum=`echo "$(compute_sha256 < "$filename")" | tr [A-Z] [a-z]`
+    [ -n "$computed_checksum" ] || return 1
+  else
+    local computed_checksum=`echo "$(compute_sha1 < "$filename")" | tr [A-Z] [a-z]`
+    [ -n "$computed_checksum" ] || return 1
+  fi
 
   if [ "$expected_checksum" != "$computed_checksum" ]; then
     { echo

--- a/share/node-build/4.0.0
+++ b/share/node-build/4.0.0
@@ -1,1 +1,1 @@
-install_package "node-v4.0.0" "http://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz#d66f3727384b9b5c5fbf46f8db723d726e2f5900"
+install_package "node-v4.0.0" "http://nodejs.org/dist/v4.0.0/node-v4.0.0.tar.gz#e110e5a066f3a6fe565ede7dd66f3727384b9b5c5fbf46f8db723d726e2f5900"

--- a/test/cache.bats
+++ b/test/cache.bats
@@ -38,7 +38,7 @@ setup() {
 
 
 @test "cached package with valid checksum" {
-  stub sha1 true "echo 83e6d7725e20166024a1eb74cde80677"
+  stub sha1 true "echo c2dca7d96803baebcdc7eb831eaaca9963330627"
   stub curl
 
   cp "${FIXTURE_ROOT}/package-1.0.0.tar.gz" "$NODE_BUILD_CACHE_PATH"

--- a/test/checksum.bats
+++ b/test/checksum.bats
@@ -18,8 +18,8 @@ export NODE_BUILD_CACHE_PATH=
 }
 
 
-@test "package URL with valid checksum" {
-  stub sha1 true "echo 83e6d7725e20166024a1eb74cde80677"
+@test "package URL with valid sha1 checksum" {
+  stub sha1 true "echo c2dca7d96803baebcdc7eb831eaaca9963330627"
   stub curl "-C - -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${6##*/} \$4"
 
   install_fixture definitions/with-checksum
@@ -30,9 +30,21 @@ export NODE_BUILD_CACHE_PATH=
   unstub sha1
 }
 
+@test "package URL with valid sha256 checksum" {
+  stub sha1 true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
+  stub curl "-C - -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${6##*/} \$4"
+
+  install_fixture definitions/with-checksum-sha256
+  [ "$status" -eq 0 ]
+  [ -x "${INSTALL_ROOT}/bin/package" ]
+
+  unstub curl
+  unstub sha1
+}
+
 
 @test "package URL with invalid checksum" {
-  stub sha1 true "echo 83e6d7725e20166024a1eb74cde80677"
+  stub sha1 true "echo c2dca7d96803baebcdc7eb831eaaca9963330627"
   stub curl "-C - -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${6##*/} \$4"
 
   install_fixture definitions/with-invalid-checksum

--- a/test/fixtures/definitions/with-checksum
+++ b/test/fixtures/definitions/with-checksum
@@ -1,1 +1,1 @@
-install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#83e6d7725e20166024a1eb74cde80677" copy
+install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#c2dca7d96803baebcdc7eb831eaaca9963330627" copy

--- a/test/fixtures/definitions/with-checksum-sha256
+++ b/test/fixtures/definitions/with-checksum-sha256
@@ -1,0 +1,1 @@
+install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5" copy

--- a/test/mirror.bats
+++ b/test/mirror.bats
@@ -34,7 +34,7 @@ export NODE_BUILD_MIRROR_URL=http://mirror.example.com
 
 
 @test "package URL with checksum hits mirror first" {
-  local checksum="83e6d7725e20166024a1eb74cde80677"
+  local checksum="c2dca7d96803baebcdc7eb831eaaca9963330627"
   local mirror_url="${NODE_BUILD_MIRROR_URL}/$checksum"
 
   stub sha1 true "echo $checksum"
@@ -51,7 +51,7 @@ export NODE_BUILD_MIRROR_URL=http://mirror.example.com
 
 
 @test "package is fetched from original URL if mirror download fails" {
-  local checksum="83e6d7725e20166024a1eb74cde80677"
+  local checksum="c2dca7d96803baebcdc7eb831eaaca9963330627"
   local mirror_url="${NODE_BUILD_MIRROR_URL}/$checksum"
 
   stub sha1 true "echo $checksum"
@@ -68,7 +68,7 @@ export NODE_BUILD_MIRROR_URL=http://mirror.example.com
 
 
 @test "package is fetched from original URL if mirror download checksum is invalid" {
-  local checksum="83e6d7725e20166024a1eb74cde80677"
+  local checksum="c2dca7d96803baebcdc7eb831eaaca9963330627"
   local mirror_url="${NODE_BUILD_MIRROR_URL}/$checksum"
 
   stub sha1 true "echo invalid" "echo $checksum"

--- a/tools/node_scraper.js
+++ b/tools/node_scraper.js
@@ -10,7 +10,13 @@ var http = require('http'),
 			parts,
 			filePath
 
-		shaUrl += /^(v4)/g.test(version) ? "SHASUMS256.txt" : "SHASUMS.txt"
+	        if(/^(v4)/g.test(version)) {
+	          shaUrl += "SHASUMS256.txt"
+	          checksum = /[\da-zA-Z]{64}  node-v[\d]{1,2}\.[\d]{1,2}\.[\d]{1,2}.tar.gz/gi
+	        } else {
+	          shaUrl += "SHASUMS.txt"
+	          checksum = /[\da-zA-Z]{40}  node-v[\d]{1,2}\.[\d]{1,2}\.[\d]{1,2}.tar.gz/gi
+	        }
 
 		http.get(shaUrl, function( res ){
 
@@ -22,7 +28,7 @@ var http = require('http'),
 
 			res.on('end', function(){
 
-				shaLine = shaData.match(/[\da-zA-Z]{40}  node-v[\d]{1,2}\.[\d]{1,2}\.[\d]{1,2}.tar.gz/gi)
+                		shaLine = shaData.match(checksum)
 
 				if(shaLine && shaLine.length){
 


### PR DESCRIPTION
Hello. I've made a mistake with the previous request that is corrected on this one. Sorry and thanks!

- updated 4.0.0 definition
- updated `scraper.js` it only takes 40chars from hash (SHASUMS256.txt)
- added sha256 computation to node-build otherwise it will not match
- updated tests