### PR TITLE
remove compilation fallback code

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -111,6 +111,10 @@ build_failed() {
     echo " ($(os_information) using $(version))"
     echo
 
+    if [ -n "$BINARY_MESSAGE" ]; then
+      printf "$BINARY_MESSAGE"
+    fi
+
     if ! rmdir "${BUILD_PATH}" 2>/dev/null; then
       echo "Inspect or clean up the working tree at ${BUILD_PATH}"
 
@@ -168,9 +172,8 @@ try_install_binary(){
     local url="$BINARY_URL"
     unset BINARY_URL
 
+    BINARY_MESSAGE="Binary installation failed; try compiling from source with \`--compile\` flag\n\n"
     install_binary "$url"
-  else
-    return 1
   fi
 }
 
@@ -214,6 +217,8 @@ install_binary() {
 }
 
 install_package_using() {
+  try_install_binary
+
   local package_type="$1"
   local package_type_nargs="$2"
   local package_name="$3"
@@ -223,7 +228,6 @@ install_package_using() {
   local make_args=( "$package_name" )
   local arg last_arg
 
-  try_install_binary && return
 
   for arg in "${@:$(( $package_type_nargs + 1 ))}"; do
     if [ "$last_arg" = "--if" ]; then
@@ -235,7 +239,7 @@ install_package_using() {
   done
 
   pushd "$BUILD_PATH" >&4
-  "fetch_${package_type}" "${fetch_args[@]}" || return 1
+  "fetch_${package_type}" "${fetch_args[@]}"
   make_package "${make_args[@]}"
   popd >&4
 
@@ -416,7 +420,7 @@ fetch_tarball() {
     echo "Downloading ${tarball_filename}..." >&2
     http head "$mirror_url" &&
     download_tarball "$mirror_url" "$package_filename" "$checksum" ||
-    download_tarball "$package_url" "$package_filename" "$checksum" || return 1
+    download_tarball "$package_url" "$package_filename" "$checksum"
   fi
 
   { if tar $tar_args "$package_filename"; then

--- a/test/binaries.bats
+++ b/test/binaries.bats
@@ -47,15 +47,14 @@ DEF
   assert_output_contains 'Installed package-1.0.0'
 }
 
-@test "falls back to compilation if binary installation fails" {
+@test "emits --compile help if binary installation fails" {
   run_inline_definition <<DEF
 binary darwin-x64 "http://example.com/packages/binary-1.0.0.tar.gz#invalidchecksum"
 install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz" copy
 DEF
 
-  assert_success
+  assert_failure
   assert_output_contains 'Downloading binary-1.0.0.tar.gz'
-  assert_output_contains 'Downloading package-1.0.0.tar.gz'
-  assert_output_contains 'Installing package-1.0.0...'
-  assert_output_contains 'Installed package-1.0.0'
+  assert_output_contains 'BUILD FAILED'
+  assert_output_contains 'Binary installation failed; try compiling from source with `--compile` flag'
 }


### PR DESCRIPTION
rather than attempting to seamlessly handle a failed binary install,
just throw an error, emit a helpful message to try compiling from
source, and exit

let the user decide to do a compile if they wish. this simplifies all
the return status code/ERR trap stuff