### PR TITLE
Support distro-specific binaries

### DIFF
--- a/bin/node-build
+++ b/bin/node-build
@@ -175,6 +175,8 @@ platform() {
       *"Red Hat"* ) distro=redhat ;;
       *Gentoo*    ) distro=gentoo ;;
     esac
+  elif [ "$os" = freebsd ]; then
+    distro="$os$(uname -r | sed 's/[^[:digit:]].*//')"
   fi
 
   echo "${arch}:${os}:${distro}"

--- a/bin/node-build
+++ b/bin/node-build
@@ -161,6 +161,7 @@ platform() {
 
   arch="$(uname -m)"
   case "$arch" in
+    arm64 | aarch64 )          arch=arm64 ;;
     x86_64 | amd64 | i686-64 ) arch=x64 ;;
     i[36]86* | [ix]86pc )      arch=x86 ;;
   esac

--- a/bin/node-build
+++ b/bin/node-build
@@ -157,7 +157,7 @@ num_cpu_cores() {
 }
 
 platform() {
-  local arch os
+  local arch os distro
 
   arch="$(uname -m)"
   case "$arch" in
@@ -167,7 +167,17 @@ platform() {
 
   os="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
-  echo "${arch}:${os}"
+  if type -p lsb_release >/dev/null; then
+    case "$(lsb_release -sir)" in
+      *Ubuntu*    ) distro=ubuntu ;;
+      *Debian*    ) distro=debian ;;
+      *SUSE*      ) distro=suse ;;
+      *"Red Hat"* ) distro=redhat ;;
+      *Gentoo*    ) distro=gentoo ;;
+    esac
+  fi
+
+  echo "${arch}:${os}:${distro}"
 }
 
 matches_platform() {
@@ -176,7 +186,8 @@ matches_platform() {
   IFS=: platform=( $(platform) )
   IFS="$OLDIFS"
 
-  [ "${platform[1]}-${platform[0]}" = "$match" ]
+  [ "${platform[1]}-${platform[0]}" = "$match" ] ||
+  [ "${platform[2]}-${platform[0]}" = "$match" ]
 }
 
 try_binary(){

--- a/test/binaries.bats
+++ b/test/binaries.bats
@@ -25,6 +25,23 @@ OUT
   refute_line 'Installing package-1.0.0...'
 }
 
+@test "matches distro if os doesn't match" {
+  stub lsb_release '-sir : echo 15.10 Ubuntu'
+  run_inline_definition <<DEF
+binary ubuntu-x64 "http://example.com/packages/binary-1.0.0.tar.gz"
+install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz" copy
+DEF
+
+  assert_success
+  assert_output <<OUT
+Downloading binary-1.0.0.tar.gz...
+-> http://example.com/packages/binary-1.0.0.tar.gz
+Installing binary-1.0.0...
+Installed binary-1.0.0 to ${BATS_TMPDIR}/install
+OUT
+  refute_line 'Installing package-1.0.0...'
+}
+
 @test "installs first of multiple matching binaries" {
   run_inline_definition <<DEF
 binary darwin-x64 "http://example.com/packages/binary-1.0.0.tar.gz"


### PR DESCRIPTION
Presently, we classify any Linux (as reported by `uname -s`) as 'linux'. But some nodes, like jxcore, have distro-specific builds. So instead of only matching directly against `uname -s`, we can try to determine the distro using `lsb_release` (or `uname -r` in freebsd's case). So now we can report back:

1. normalized architecture (arm64, x64, x86)
2. os (sunos, darwin, linux)
3. distro (debian, ubuntu, gentoo, freebsd, etc)

Nodejs and iojs only care about 'linux', we first attempt to match to OS, but *also* try to match against distro. If *either* match, then we use the given binary.