### PR TITLE
Add -next and -dev branches for lts releases

### DIFF
--- a/share/node-build/0.10-dev
+++ b/share/node-build/0.10-dev
@@ -1,0 +1,1 @@
+install_git "0.10-dev" "https://github.com/nodejs/node.git" "v0.10-staging" standard

--- a/share/node-build/0.10-next
+++ b/share/node-build/0.10-next
@@ -1,0 +1,1 @@
+install_git "0.10-next" "https://github.com/nodejs/node.git" "v0.10" standard

--- a/share/node-build/0.12-dev
+++ b/share/node-build/0.12-dev
@@ -1,0 +1,1 @@
+install_git "0.12-dev" "https://github.com/nodejs/node.git" "v0.12-staging" standard

--- a/share/node-build/0.12-next
+++ b/share/node-build/0.12-next
@@ -1,0 +1,1 @@
+install_git "0.12-next" "https://github.com/nodejs/node.git" "v0.12" standard

--- a/share/node-build/4.x-dev
+++ b/share/node-build/4.x-dev
@@ -1,0 +1,1 @@
+install_git "4.x-dev" "https://github.com/nodejs/node.git" "v4.x-staging" standard

--- a/share/node-build/4.x-next
+++ b/share/node-build/4.x-next
@@ -1,0 +1,1 @@
+install_git "4.x-next" "https://github.com/nodejs/node.git" "v4.x" standard

--- a/share/node-build/5.x-dev
+++ b/share/node-build/5.x-dev
@@ -1,0 +1,1 @@
+install_git "5.x-dev" "https://github.com/nodejs/node.git" "master" standard

--- a/share/node-build/5.x-dev
+++ b/share/node-build/5.x-dev
@@ -1,1 +1,0 @@
-install_git "5.x-dev" "https://github.com/nodejs/node.git" "master" standard

--- a/share/node-build/5.x-next
+++ b/share/node-build/5.x-next
@@ -1,0 +1,1 @@
+install_git "5.x-next" "https://github.com/nodejs/node.git" "v5.x" standard

--- a/share/node-build/node-dev
+++ b/share/node-build/node-dev
@@ -1,0 +1,1 @@
+install_git "node-dev" "https://github.com/nodejs/node.git" "master" standard


### PR DESCRIPTION
There are currently three maintained LTS release lines: `v0.10`, `v0.12`, and `v4.x`, as well as the current stable release `v5.x`.  [Releases are cut](https://github.com/nodejs/node/blob/master/COLLABORATOR_GUIDE.md#how-are-lts-branches-managed) directly out of these branches, so building off these branches is the '-next' release for each line.

Added:
- `0.10-next` builds off `v0.10` branch
- `0.12-next` builds off `v0.12` branch
- `4.x-next` builds off `v4.x` branch
- `5.x-next` builds off `v5.x` branch

Commits are cherry picked out of master and into -staging branches for each line (some PRs are made directly against the -staging branches). These are each the most 'active' development for each line:

Added:
- `0.10-dev` builds off `v0.10-staging` branch
- `0.12-dev` builds off `v0.12-staging` branch
- `4.x-dev` builds off `v4.x-staging` branch

5.x isn't an LTS line, so there isn't a v5.x-staging branch. But as 5.x is the current stable release, 'master' is the dev branch for 5.x line:

Added:
- ~~`5.x-dev`~~ `node-dev` builds off `master` branch

My only concern is with the naming. `*-next` fits well with the LTS branches, as they contain what will soon become a release. As far as the -dev builds, I've debated using `*-dev` vs `*-staging`. -staging would be nice because it matches the branch it builds from. But as a user, seeing only `-next` and `-staging`, I don't think it's immediately clear which one is more stable and which is more bleeding edge. `-next` vs `-dev`, on the other hand, seems clear to me.