### PR TITLE
Update jxcore npmjx shas

### DIFF
--- a/share/node-build/jxcore+sm-0.3.1.0
+++ b/share/node-build/jxcore+sm-0.3.1.0
@@ -16,4 +16,4 @@ binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0310/jx_ub64sm.zip#e299ee14fa
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0310/jx_ub32sm.zip#ac85fe3ac35149aeb4449d6899e82a98ac5e6ebc8fc43fa6c16bdcf666979ab8"
 
 install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df" jxcore_spidermonkey standard
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#1071b88dbacbe366ded078ad4ae4e387ec61fe8c1cf48e248f8b82924bb9d54f" jxcore_npm
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm

--- a/share/node-build/jxcore+v8-0.3.1.0
+++ b/share/node-build/jxcore+v8-0.3.1.0
@@ -16,4 +16,4 @@ binary ubuntu-x64 "https://jxcore.s3.amazonaws.com/0310/jx_ub64v8.zip#e21abde7d6
 binary ubuntu-x86 "https://jxcore.s3.amazonaws.com/0310/jx_ub32v8.zip#d533f8fe93000b3ef595cded488ae52b7817fb6cf3860d1d28e7067694ec5e85"
 
 install_package jxcore-0.3.1.0 "https://github.com/jxcore/jxcore/archive/v0.3.1.0.tar.gz#cae9dac0602667b5b5dedf2ac23445e2875c2bfb91cbdfd7b370790f8a0c96df"
-install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#1071b88dbacbe366ded078ad4ae4e387ec61fe8c1cf48e248f8b82924bb9d54f" jxcore_npm
+install_package npm "https://s3.amazonaws.com/nodejx/npmjx310.tar.gz#3c8e1b1fed9be44c4ec6fd09e6978a29c3e466f684e2812f6762c0a6d28fb85c" jxcore_npm


### PR DESCRIPTION
The package has been updated (fixed executable permissions: https://github.com/jxcore/jxcore/issues/749)